### PR TITLE
Store resolved magnet links as torrents. Keep compatibility and functionality.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "torrent-tracker-health": "git+https://github.com/PTCE-Public/torrent-tracker-health.git",
     "underscore": "^1.8.3",
     "upnp-mediarenderer-client": "^1.2.1",
-    "xmlbuilder": "^2.6.2"
+    "xmlbuilder": "^2.6.2",
+    "parse-torrent": "~5.7.3"
   },
   "devDependencies": {
     "del": "^2.2.0",

--- a/src/app/lib/providers/torrent_cache.js
+++ b/src/app/lib/providers/torrent_cache.js
@@ -211,6 +211,7 @@
 
             var deferred = Q.defer(),
                 error = false,
+                parseTorrent = require('parse-torrent'),
                 engine = peerflix(torrent, {
                     list: true
                 }); // just list files, this won't start the torrent server
@@ -243,14 +244,14 @@
                 var resolvedTorrentPath = engine.path;
                 clearTimeout(currentTID);
                 if (resolvedTorrentPath) {
-                    // copy resolved path to cache so it will be awailable next time
-                    Common.copyFile(resolvedTorrentPath + '.torrent', filePath, function (err) {
-                        if (err) {
-                            error = err;
-                        }
-                        resolve();
-                        destroyEngine();
-                    });
+
+                    var torrentInfo = engine.torrent;
+                    torrentInfo.announce = _.union(engine.torrent.announce, parseTorrent(torrent).announce);
+
+                    fs.writeFileSync(filePath, parseTorrent.toTorrentFile(torrentInfo)); // save torrent
+
+                    resolve();
+                    destroyEngine();
                 } else {
                     error = 'TorrentCache.handlemagnet() engine returned no file';
                     destroyEngine();

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -127,7 +127,7 @@
             } else if (!Settings.droppedStoredMagnet) {
 				//else if (Settings.droppedMagnet && !Settings.droppedStoredMagnet) {
                 _file = Settings.droppedMagnet,
-                    file = formatMagnet(_file);
+                    file = formatMagnet(_file) + '.torrent';
 					//alert("droppedMagnet, droppedStoredMagnet=false: "+file);
             } else if (Settings.droppedStoredMagnet) {
 				//else if (Settings.droppedMagnet && Settings.droppedStoredMagnet) {

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -174,7 +174,7 @@
                     // if (Settings.droppedStoredMagnet) {
                     //     torrent_name = Settings.droppedStoredMagnet;
                     // }
-                    fs.unlinkSync(target + torrent_name + '.magnet.torrent'); // remove the magnet
+                    fs.unlinkSync(target + torrent_name + '.torrent'); // remove the magnet
                     win.debug('Torrent Collection: deleted', torrent_name);
                     //alert('Torrent Collection: deleted', torrent_name);
                 } else {
@@ -182,7 +182,7 @@
                         fs.mkdir(target); // create directory if needed
                     }
 
-                    fs.writeFileSync(target + torrent_name + '.magnet.torrent', fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
+                    fs.writeFileSync(target + torrent_name + '.torrent', fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
                     win.debug('Torrent Collection: added', torrent_name);
                     //alert('Torrent Collection: added', torrent_name);
                 }

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -146,44 +146,45 @@
         },
 
         storeTorrent: function () {
-            var source = App.settings.tmpLocation + '/',
-                target = require('nw.gui').App.dataPath + '/TorrentCollection/',
-                file,
-                _file;
+            var source = require('os').tmpDir() + '/Popcorn-Time/TorrentCache/',
+                target = require('nw.gui').App.dataPath + '/TorrentCollection/';
 
             if (Settings.droppedTorrent) {
-                file = Settings.droppedTorrent;
+                var torrent_name = Settings.droppedTorrent;
+                var cached_torrent_hashname = Common.md5(path.basename(torrent_name));
 
                 if (this.isTorrentStored()) {
-                    fs.unlinkSync(target + file); // remove the torrent
-                    win.debug('Torrent Collection: deleted', file);
-                    //alert('Torrent Collection: deleted', file);
+                    fs.unlinkSync(target + torrent_name); // remove the torrent
+                    win.debug('Torrent Collection: deleted', torrent_name);
+                    //alert('Torrent Collection: deleted', torrent_name);
                 } else {
                     if (!fs.existsSync(target)) {
                         fs.mkdir(target); // create directory if needed
                     }
-                    fs.writeFileSync(target + file, fs.readFileSync(source + file)); // save torrent
-                    win.debug('Torrent Collection: added', file);
-                    //alert('Torrent Collection: added', file);
+                    fs.writeFileSync(target + torrent_name, fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
+                    win.debug('Torrent Collection: added', torrent_name);
+                    //alert('Torrent Collection: added', torrent_name);
                 }
             } else if (Settings.droppedMagnet) {
-                _file = Settings.droppedMagnet,
-                    file = formatMagnet(_file);
+                var magnet_link = Settings.droppedMagnet;
+                var torrent_name = formatMagnet(magnet_link);
+                var cached_torrent_hashname = Common.md5(path.basename(magnet_link));
 
                 if (this.isTorrentStored()) {
-                    if (Settings.droppedStoredMagnet) {
-                        file = Settings.droppedStoredMagnet;
-                    }
-                    fs.unlinkSync(target + file); // remove the magnet
-                    win.debug('Torrent Collection: deleted', file);
-                    //alert('Torrent Collection: deleted', file);
+                    // if (Settings.droppedStoredMagnet) {
+                    //     torrent_name = Settings.droppedStoredMagnet;
+                    // }
+                    fs.unlinkSync(target + torrent_name + '.magnet.torrent'); // remove the magnet
+                    win.debug('Torrent Collection: deleted', torrent_name);
+                    //alert('Torrent Collection: deleted', torrent_name);
                 } else {
                     if (!fs.existsSync(target)) {
                         fs.mkdir(target); // create directory if needed
                     }
-                    fs.writeFileSync(target + file, _file); // save magnet link inside readable file
-                    win.debug('Torrent Collection: added', file);
-                    //alert('Torrent Collection: added', file);
+
+                    fs.writeFileSync(target + torrent_name + '.magnet.torrent', fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
+                    win.debug('Torrent Collection: added', torrent_name);
+                    //alert('Torrent Collection: added', torrent_name);
                 }
             }
             this.isTorrentStored(); // trigger button change

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -146,45 +146,44 @@
         },
 
         storeTorrent: function () {
+            var torrent_display_name, torrent_file_name, cached_torrent_hashname;
+
             var source = require('os').tmpDir() + '/Popcorn-Time/TorrentCache/',
                 target = require('nw.gui').App.dataPath + '/TorrentCollection/';
 
             if (Settings.droppedTorrent) {
-                var torrent_name = Settings.droppedTorrent;
-                var cached_torrent_hashname = Common.md5(path.basename(torrent_name));
+                torrent_file_name = Settings.droppedTorrent;
+                cached_torrent_hashname = Common.md5(path.basename(torrent_file_name));
 
                 if (this.isTorrentStored()) {
-                    fs.unlinkSync(target + torrent_name); // remove the torrent
-                    win.debug('Torrent Collection: deleted', torrent_name);
-                    //alert('Torrent Collection: deleted', torrent_name);
+                    fs.unlinkSync(target + torrent_file_name); // remove the torrent
+                    win.debug('Torrent Collection: deleted', torrent_file_name);
+                    //alert('Torrent Collection: deleted', torrent_file_name);
                 } else {
                     if (!fs.existsSync(target)) {
                         fs.mkdir(target); // create directory if needed
                     }
-                    fs.writeFileSync(target + torrent_name, fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
-                    win.debug('Torrent Collection: added', torrent_name);
-                    //alert('Torrent Collection: added', torrent_name);
+                    fs.writeFileSync(target + torrent_file_name, fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
+                    win.debug('Torrent Collection: added', torrent_file_name);
+                    //alert('Torrent Collection: added', torrent_file_name);
                 }
             } else if (Settings.droppedMagnet) {
-                var magnet_link = Settings.droppedMagnet;
-                var torrent_name = formatMagnet(magnet_link);
-                var cached_torrent_hashname = Common.md5(path.basename(magnet_link));
+                torrent_display_name = formatMagnet(Settings.droppedMagnet);
+                torrent_file_name = Settings.droppedStoredMagnet ? Settings.droppedStoredMagnet : torrent_display_name;
+                cached_torrent_hashname = Common.md5(path.basename(Settings.droppedMagnet));
 
-                if (this.isTorrentStored()) {
-                    // if (Settings.droppedStoredMagnet) {
-                    //     torrent_name = Settings.droppedStoredMagnet;
-                    // }
-                    fs.unlinkSync(target + torrent_name + '.torrent'); // remove the magnet
-                    win.debug('Torrent Collection: deleted', torrent_name);
-                    //alert('Torrent Collection: deleted', torrent_name);
+                if (this.isTorrentStored()) { // this is only for compatability, since we don't have magnet links stored anymore
+                    fs.unlinkSync(target + torrent_file_name); // remove the magnet
+                    win.debug('Torrent Collection: deleted', torrent_file_name);
+                    //alert('Torrent Collection: deleted', torrent_file_name);
                 } else {
                     if (!fs.existsSync(target)) {
                         fs.mkdir(target); // create directory if needed
                     }
 
-                    fs.writeFileSync(target + torrent_name + '.torrent', fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
-                    win.debug('Torrent Collection: added', torrent_name);
-                    //alert('Torrent Collection: added', torrent_name);
+                    fs.writeFileSync(target + torrent_file_name + '.torrent', fs.readFileSync(source + cached_torrent_hashname + '.torrent')); // save torrent
+                    win.debug('Torrent Collection: added', torrent_file_name);
+                    //alert('Torrent Collection: added', torrent_file_name);
                 }
             }
             this.isTorrentStored(); // trigger button change

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -345,8 +345,12 @@
                 var _file = $(e.currentTarget.parentNode).context.innerText,
                     file = _file.substring(0, _file.length - 2); // avoid ENOENT
                 
-                torrentInfo = parseTorrent(fs.readFileSync(collection + file));
-                magnetLink = parseTorrent.toMagnetURI(torrentInfo);
+                if (file.indexOf('.torrent') !== -1) {
+                    torrentInfo = parseTorrent(fs.readFileSync(collection + file));
+                    magnetLink = parseTorrent.toMagnetURI(torrentInfo);
+                } else { // Only for compatability
+                    magnetLink = fs.readFileSync(collection + file, 'utf8');
+                }
             } else {
                 // search result
                 magnetLink = $(e.currentTarget.parentNode).context.attributes['data-file'].value;

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -336,13 +336,17 @@
             e.stopPropagation();
 
             var magnetLink,
-                gui = require('nw.gui');
+                torrentInfo,
+                gui = require('nw.gui'),
+                parseTorrent = require('parse-torrent');
 
             if ($(e.currentTarget.parentNode).context.className === 'file-item') {
                 // stored
                 var _file = $(e.currentTarget.parentNode).context.innerText,
                     file = _file.substring(0, _file.length - 2); // avoid ENOENT
-                magnetLink = fs.readFileSync(collection + file, 'utf8');
+                
+                torrentInfo = parseTorrent(fs.readFileSync(collection + file));
+                magnetLink = parseTorrent.toMagnetURI(torrentInfo);
             } else {
                 // search result
                 magnetLink = $(e.currentTarget.parentNode).context.attributes['data-file'].value;

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -5,6 +5,16 @@
         collection = path.join(require('nw.gui').App.dataPath + '/TorrentCollection/'),
         files;
 
+    var readCollection = function (dir) {
+        return fs.readdirSync(dir).map(function(v) { 
+                      return { name:v,
+                               time:fs.statSync(dir + v).mtime.getTime()
+                             }; 
+                   })
+                   .sort(function(a, b) { return b.time - a.time; })
+                   .map(function(v) { return v.name; });
+    }
+
     var TorrentCollection = Backbone.Marionette.ItemView.extend({
         template: '#torrent-collection-tpl',
         className: 'torrent-collection',
@@ -31,7 +41,8 @@
                 fs.mkdirSync(collection);
                 win.debug('TorrentCollection: data directory created');
             }
-            this.files = fs.readdirSync(collection);
+            this.model = new Backbone.Model();
+            this.model.attributes.files = readCollection(collection);
             this.searchEngine = Settings.onlineSearchEngine;
         },
 
@@ -50,7 +61,7 @@
             $('.engine-icon').removeClass('active');
             $('#' + this.searchEngine.toLowerCase() + '-icon').addClass('active');
             $('#online-input').focus();
-            if (this.files[0]) {
+            if (this.model.attributes.files[0]) {
                 $('.notorrents-info').css('display', 'none');
                 $('.collection-actions').css('display', 'block');
                 $('.torrents-info').css('display', 'block');
@@ -358,7 +369,7 @@
             win.debug('Torrent Collection: deleted', file);
 
             // update collection
-            this.files = fs.readdirSync(collection);
+            this.model.attributes.files = readCollection(collection);
             this.render();
         },
 
@@ -398,7 +409,7 @@
             }
 
             // update collection
-            this.files = fs.readdirSync(collection);
+            this.model.attributes.files = readCollection(collection);
             this.render();
         },
 

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -34,13 +34,7 @@
 
         <div class="torrents-info">
             <ul class="file-list">
-                <% _.each(fs.readdirSync(require('nw.gui').App.dataPath + '/TorrentCollection/').map(function(v) { 
-                  return { name:v,
-                           time:fs.statSync(require('nw.gui').App.dataPath + '/TorrentCollection/' + v).mtime.getTime()
-                         }; 
-               })
-               .sort(function(a, b) { return b.time - a.time; })
-               .map(function(v) { return v.name; }), function(file, index) { %>
+                <% _.each(files, function(file, index) { %>
                     <li class="file-item" data-index="<%=file.index%>" data-file="<%=index%>">
                         <a><%=file%></a>
 

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -38,10 +38,10 @@
                     <li class="file-item" data-index="<%=file.index%>" data-file="<%=index%>">
                         <a><%=file%></a>
 
-                   <% if (file.indexOf('.torrent') !== -1) { %>
-                        <div class="item-icon torrent-icon"></div>
-                   <% } else { %>
+                   <% if (file.indexOf('.magnet.torrent') !== -1) { %>
                         <div class="item-icon magnet-icon tooltipped" data-toogle="tooltip" data-placement="right" title="<%=i18n.__("Magnet link") %>"></div>
+                   <% } else { %>
+                        <div class="item-icon torrent-icon"></div>
                     <% } %>
                         <i class="fa fa-trash-o item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
                         <i class="fa fa-pencil item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -37,12 +37,7 @@
                 <% _.each(files, function(file, index) { %>
                     <li class="file-item" data-index="<%=file.index%>" data-file="<%=index%>">
                         <a><%=file%></a>
-
-                   <% if (file.indexOf('.magnet.torrent') !== -1) { %>
                         <div class="item-icon magnet-icon tooltipped" data-toogle="tooltip" data-placement="right" title="<%=i18n.__("Magnet link") %>"></div>
-                   <% } else { %>
-                        <div class="item-icon torrent-icon"></div>
-                    <% } %>
                         <i class="fa fa-trash-o item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
                         <i class="fa fa-pencil item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
                         </a>

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -34,7 +34,13 @@
 
         <div class="torrents-info">
             <ul class="file-list">
-                <% _.each(fs.readdirSync(require('nw.gui').App.dataPath + '/TorrentCollection/'), function(file, index) { %>
+                <% _.each(fs.readdirSync(require('nw.gui').App.dataPath + '/TorrentCollection/').map(function(v) { 
+                  return { name:v,
+                           time:fs.statSync(require('nw.gui').App.dataPath + '/TorrentCollection/' + v).mtime.getTime()
+                         }; 
+               })
+               .sort(function(a, b) { return b.time - a.time; })
+               .map(function(v) { return v.name; }), function(file, index) { %>
                     <li class="file-item" data-index="<%=file.index%>" data-file="<%=index%>">
                         <a><%=file%></a>
 


### PR DESCRIPTION
Reasons:

. Instant file list resolve
. more usable torrent folder
 . copying magnet link works (is generated) for both torrents and magnet links

This patch closes PopcornTimeCommunity/desktop#81 (torrent cache becomes implemented here) and also closes PopcornTimeCommunity/desktop#79 (built on previous pull request)

Requires npm install , guess that would mean version change of more than just a build.